### PR TITLE
Add utility for making paginated commands

### DIFF
--- a/commands/commands.js
+++ b/commands/commands.js
@@ -1,23 +1,2 @@
-const chunk = require("lodash.chunk");
-
-module.exports = {
-    command: "commands [page]",
-	describe: "List commands and their description.",
-	builder: builder => {
-		builder.positional("page", {
-			type: "number",
-			describe: "The page number to view.",
-			default: 1,
-		});
-	},
-    handler: args => {
-		const allCommands = args.usage.map(command => `${args.prefix}${command[0]}: ${command[1]}`).sort();
-		const list = chunk(allCommands, 5);
-
-		if (args.page <= list.length && args.page > 0) {
-			args.send(`${allCommands.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
-		} else {
-			args.send("That's an invalid page number!");
-		}
-	},
-};
+const paginate = require("./../utils/paginate.js");
+module.exports = paginate("commands", "List commands and their description.", args.usage.map(command => `${args.prefix}${command[0]}: ${command[1]}`), "commands");

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -1,4 +1,7 @@
 const paginate = require("./../utils/paginate.js");
-module.exports = paginate("commands", "List commands and their description.", args => {
+module.exports = paginate("commands", args => {
 	return args.usage.map(command => `${args.prefix}${command[0]}: ${command[1]}`);
-}, "commands");
+}, {
+	description: "List commands and their description.",
+	dataType: "commands",
+});

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -1,2 +1,4 @@
 const paginate = require("./../utils/paginate.js");
-module.exports = paginate("commands", "List commands and their description.", args.usage.map(command => `${args.prefix}${command[0]}: ${command[1]}`), "commands");
+module.exports = paginate("commands", "List commands and their description.", args => {
+	return args.usage.map(command => `${args.prefix}${command[0]}: ${command[1]}`);
+}, "commands");

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -4,10 +4,10 @@ const chunk = require("lodash.chunk");
 	* Creates a pagined command using a set of data.
 	* @param {string} command The name of the command.
 	* @param {string} description The command description.
-	* @param {*[]} data The data to paginate.
+	* @param {function|*[]} data The data to paginate.
 	* @param {string} dataType The type of data being displayed.
 */
-module.exports = (command, description, data = [], dataType = "items") => {
+module.exports = async (command, description, data = [], dataType = "items") => {
     command: command + " [page]",
 	describe: description,
 	builder: builder => {
@@ -18,10 +18,12 @@ module.exports = (command, description, data = [], dataType = "items") => {
 		});
 	},
     handler: args => {
-		const list = chunk(data.sort(), 5);
+	    	const resolvedData = typeof data === "function" ? await data(args) : data;
+	    
+		const list = chunk(resolvedData.sort(), 5);
 
 		if (args.page <= list.length && args.page > 0) {
-			args.send(`${data.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+			args.send(`${resolvedData.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
 		} else {
 			args.send("That's an invalid page number!");
 		}

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -14,6 +14,7 @@ const chunk = require("lodash.chunk");
 	* @param {(DataGetFunction|*)} [data] The data to paginate.
 	* @param [opts] Other options.
 	* @param {string} [opts.description] The command description.
+	* @param {string[]} [opts.aliases] The command's aliases.
 	* @param {string} [opts.dataType] The plural word used to describe the data.
 	* @param {string} [opts.footer] Text to display after the data as a footer.
 */
@@ -22,6 +23,7 @@ module.exports = (command, data = [], opts = {}) => {
 		description: "",
 		aliases: [],
 		dataType: "items",
+		footer: "",
 	}, opts);
 	
 	return {

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -15,25 +15,27 @@ const chunk = require("lodash.chunk");
 	* @param {(DataGetFunction|*)} data The data to paginate.
 	* @param {string} dataType The type of data being displayed.
 */
-module.exports = async (command, description, data = [], dataType = "items") => {
-    command: command + " [page]",
-	describe: description,
-	builder: builder => {
-		builder.positional("page", {
-			type: "number",
-			describe: "The page number to view.",
-			default: 1,
-		});
-	},
-    handler: args => {
-	    	const resolvedData = [].concat(typeof data === "function" ? await data(args) : data);
-	    
-		const list = chunk(resolvedData.sort(), 5);
+module.exports = (command, description, data = [], dataType = "items") => {
+	return {
+		command: command + " [page]",
+		describe: description,
+		builder: builder => {
+			builder.positional("page", {
+				type: "number",
+				describe: "The page number to view.",
+				default: 1,
+			});
+		},
+		handler: async args => {
+			const resolvedData = [].concat(typeof data === "function" ? await data(args) : data);
+			
+			const list = chunk(resolvedData.sort(), 5);
 
-		if (args.page <= list.length && args.page > 0) {
-			args.send(`${resolvedData.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
-		} else {
-			args.send("That's an invalid page number!");
-		}
-	},
+			if (args.page <= list.length && args.page > 0) {
+				args.send(`${resolvedData.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+			} else {
+				args.send("That's an invalid page number!");
+			}
+		},
+	};
 };

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -26,7 +26,7 @@ module.exports = async (command, description, data = [], dataType = "items") => 
 		});
 	},
     handler: args => {
-	    	const resolvedData = Array.concat(typeof data === "function" ? await data(args) : data);
+	    	const resolvedData = [].concat(typeof data === "function" ? await data(args) : data);
 	    
 		const list = chunk(resolvedData.sort(), 5);
 

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -5,14 +5,14 @@ const chunk = require("lodash.chunk");
 	* @name DataGetFunction
 	* @function
 	* @param args The arguments from Yargs.
-	* @returns *[]
+	* @returns *
 */
 
 /**
 	* Creates a pagined command using a set of data.
 	* @param {string} command The name of the command.
 	* @param {string} description The command description.
-	* @param {(DataGetFunction|*[])} data The data to paginate.
+	* @param {(DataGetFunction|*)} data The data to paginate.
 	* @param {string} dataType The type of data being displayed.
 */
 module.exports = async (command, description, data = [], dataType = "items") => {
@@ -26,7 +26,7 @@ module.exports = async (command, description, data = [], dataType = "items") => 
 		});
 	},
     handler: args => {
-	    	const resolvedData = typeof data === "function" ? await data(args) : data;
+	    	const resolvedData = Array.concat(typeof data === "function" ? await data(args) : data);
 	    
 		const list = chunk(resolvedData.sort(), 5);
 

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -11,10 +11,10 @@ const chunk = require("lodash.chunk");
 /**
 	* Creates a pagined command using a set of data.
 	* @param {string} command The name of the command.
-	* @param {(DataGetFunction|*)} data The data to paginate.
-	* @param opts Other options.
-	* @param {string} opts.description The command description.
-	* @param {string} opts.dataType The plural word used to describe the data.
+	* @param {(DataGetFunction|*)} [data] The data to paginate.
+	* @param [opts] Other options.
+	* @param {string} [opts.description] The command description.
+	* @param {string} [opts.dataType] The plural word used to describe the data.
 	* @param {string} [opts.footer] Text to display after the data as a footer.
 */
 module.exports = (command, data = [], opts = {}) => {

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -1,0 +1,29 @@
+const chunk = require("lodash.chunk");
+
+/**
+	* Creates a pagined command using a set of data.
+	* @param {string} command The name of the command.
+	* @param {string} description The command description.
+	* @param {*[]} data The data to paginate.
+	* @param {string} dataType The type of data being displayed.
+*/
+module.exports = (command, description, data = [], dataType = "items") => {
+    command: command + " [page]",
+	describe: description,
+	builder: builder => {
+		builder.positional("page", {
+			type: "number",
+			describe: "The page number to view.",
+			default: 1,
+		});
+	},
+    handler: args => {
+		const list = chunk(data.sort(), 5);
+
+		if (args.page <= list.length && args.page > 0) {
+			args.send(`${data.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+		} else {
+			args.send("That's an invalid page number!");
+		}
+	},
+};

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -11,11 +11,21 @@ const chunk = require("lodash.chunk");
 /**
 	* Creates a pagined command using a set of data.
 	* @param {string} command The name of the command.
-	* @param {string} description The command description.
 	* @param {(DataGetFunction|*)} data The data to paginate.
-	* @param {string} dataType The type of data being displayed.
+	* @param opts Other options.
+	* @param {string} opts.description The command description.
+	* @param {string} opts.dataType The type of data being displayed.
 */
-module.exports = (command, description, data = [], dataType = "items") => {
+module.exports = (command, data = [], opts = {}) => {
+	const options = Object.assign({
+		description: "",
+		dataType: "items",
+	}, opts);
+	
+	// legacy var names
+	const description = opts.description;
+	const dataType = opts.dataType;
+	
 	return {
 		command: command + " [page]",
 		describe: description,

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -20,6 +20,7 @@ const chunk = require("lodash.chunk");
 module.exports = (command, data = [], opts = {}) => {
 	const options = Object.assign({
 		description: "",
+		aliases: [],
 		dataType: "items",
 	}, opts);
 	
@@ -30,6 +31,7 @@ module.exports = (command, data = [], opts = {}) => {
 	return {
 		command: command + " [page]",
 		describe: description,
+		aliases: opts.aliases,
 		builder: builder => {
 			builder.positional("page", {
 				type: "number",

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -1,10 +1,18 @@
 const chunk = require("lodash.chunk");
 
 /**
+	* Gets data for pagination.
+	* @name DataGetFunction
+	* @function
+	* @param args The arguments from Yargs.
+	* @returns *[]
+*/
+
+/**
 	* Creates a pagined command using a set of data.
 	* @param {string} command The name of the command.
 	* @param {string} description The command description.
-	* @param {function|*[]} data The data to paginate.
+	* @param {(DataGetFunction|*[])} data The data to paginate.
 	* @param {string} dataType The type of data being displayed.
 */
 module.exports = async (command, description, data = [], dataType = "items") => {

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -14,7 +14,7 @@ const chunk = require("lodash.chunk");
 	* @param {(DataGetFunction|*)} data The data to paginate.
 	* @param opts Other options.
 	* @param {string} opts.description The command description.
-	* @param {string} opts.dataType The type of data being displayed.
+	* @param {string} opts.dataType The plural word used to describe the data.
 */
 module.exports = (command, data = [], opts = {}) => {
 	const options = Object.assign({
@@ -43,9 +43,9 @@ module.exports = (command, data = [], opts = {}) => {
 
 			if (args.page <= list.length && args.page > 0) {
 				if (resolvedData.length === 0) {
-					args.send("There is no data to view.");
+					args.send(`There are no ${options.dataType} to view.`);
 				} else {
-					args.send(`${resolvedData.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+					args.send(`${resolvedData.length} ${options.dataType} (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
 				}
 			} else {
 				args.send("That's an invalid page number!");

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -24,14 +24,10 @@ module.exports = (command, data = [], opts = {}) => {
 		dataType: "items",
 	}, opts);
 	
-	// legacy var names
-	const description = opts.description;
-	const dataType = opts.dataType;
-	
 	return {
 		command: command + " [page]",
-		describe: description,
-		aliases: opts.aliases,
+		describe: options.description,
+		aliases: options.aliases,
 		builder: builder => {
 			builder.positional("page", {
 				type: "number",
@@ -48,7 +44,7 @@ module.exports = (command, data = [], opts = {}) => {
 				if (resolvedData.length === 0) {
 					args.send(`There are no ${options.dataType} to view.`);
 				} else {
-					const endText = opts.footer ? "\n\n" + opts.footer : "";
+					const endText = options.footer ? "\n\n" + options.footer : "";
 					args.send(`${resolvedData.length} ${options.dataType} (page ${args.page} of ${list.length}): \n\n• ${list[args.page - 1].join("\n• ")}${endText}`);
 				}
 			} else {

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -15,6 +15,7 @@ const chunk = require("lodash.chunk");
 	* @param opts Other options.
 	* @param {string} opts.description The command description.
 	* @param {string} opts.dataType The plural word used to describe the data.
+	* @param {string} [opts.footer] Text to display after the data as a footer.
 */
 module.exports = (command, data = [], opts = {}) => {
 	const options = Object.assign({
@@ -45,7 +46,8 @@ module.exports = (command, data = [], opts = {}) => {
 				if (resolvedData.length === 0) {
 					args.send(`There are no ${options.dataType} to view.`);
 				} else {
-					args.send(`${resolvedData.length} ${options.dataType} (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+					const endText = opts.footer ? "\n\n" + opts.footer : "";
+					args.send(`${resolvedData.length} ${options.dataType} (page ${args.page} of ${list.length}): \n\n• ${list[args.page - 1].join("\n• ")}${endText}`);
 				}
 			} else {
 				args.send("That's an invalid page number!");

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -42,7 +42,11 @@ module.exports = (command, data = [], opts = {}) => {
 			const list = chunk(resolvedData.sort(), 5);
 
 			if (args.page <= list.length && args.page > 0) {
-				args.send(`${resolvedData.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+				if (resolvedData.length === 0) {
+					args.send("There is no data to view.");
+				} else {
+					args.send(`${resolvedData.length} commands (page ${args.page} of ${list.length}): \n\n• ` + list[args.page - 1].join("\n• "));
+				}
 			} else {
 				args.send("That's an invalid page number!");
 			}


### PR DESCRIPTION
This function adds a utility for making a paginated command from a data set or function returning a data set like the `commands` command, which now uses this utility.