### PR TITLE
Add a command that researches commands

### DIFF
--- a/commands/command.js
+++ b/commands/command.js
@@ -1,5 +1,5 @@
 module.exports = {
-	command: "command <name>",
+	command: "command [name]",
 	describe: "Views information about a command.",
 	aliases: [
 		"cmd",
@@ -14,5 +14,11 @@ module.exports = {
 			describe: "The command to view information about.",
 		});
 	},
-	handler: args => {},
+	handler: args => {
+		if (args.name) {
+			
+		} else {
+			args.send(`Please specify a command to view. To see all commands, do ${args.prefix}commands.`);
+		}
+	},
 };

--- a/commands/command.js
+++ b/commands/command.js
@@ -1,0 +1,18 @@
+module.exports = {
+	command: "command <name>",
+	describe: "Views information about a command.",
+	aliases: [
+		"cmd",
+		"viewcommand",
+		"viewcmd",
+		"commandinfo",
+		"cmdinfo",
+	],
+	builder: cmd => {
+		cmd.positional("name{
+			type: "string",
+			describe: "The command to view information about.",
+		});
+	},
+	handler: args => {},
+};

--- a/commands/command.js
+++ b/commands/command.js
@@ -9,7 +9,7 @@ module.exports = {
 		"cmdinfo",
 	],
 	builder: cmd => {
-		cmd.positional("name{
+		cmd.positional("name", {
 			type: "string",
 			describe: "The command to view information about.",
 		});

--- a/commands/command.js
+++ b/commands/command.js
@@ -16,7 +16,16 @@ module.exports = {
 	},
 	handler: args => {
 		if (args.name) {
-			
+			const command = args.usage.filter(usage => usage[0].split(" ")[0] === args.name)[0];
+			if (command) {
+				args.send([
+					"Command: " + args.prefix + command[0],
+					command[1] ? "Description: " + command[1] : "",
+					command[3].length > 0 ? "Aliases: " + command[3].join(", ") : "",
+				].join("\n"));
+			} else {
+				args.send("There is no command with that name.");
+			}
 		} else {
 			args.send(`Please specify a command to view. To see all commands, do ${args.prefix}commands.`);
 		}


### PR DESCRIPTION
This pull request adds the `command <name>` command, which can be used to look up information about a certain command specified by `name`. It will show the command name and arguments, aliases, description, and positional information.