### PR TITLE
Require page number to be an integer

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,15 @@ function handleCommand(command = "", channel = {}, message = {}) {
 		const unprefixedCmd = command.replace(prefix, "");
 		log.commands("recieved command '%s'", unprefixedCmd);
 
+		let chData = {};
+		
 		try {
-			const chData = JSON.parse(channel.data);
+			chData = JSON.parse(channel.data);
+		} catch {
+			log.commands("couldn't parse extra channel data, this is fine");
+		}
+
+		try {
 			yargs.parse(unprefixedCmd, {
 				prefix,
 				channel,

--- a/utils/paginate.js
+++ b/utils/paginate.js
@@ -43,11 +43,15 @@ module.exports = (command, data = [], opts = {}) => {
 			const list = chunk(resolvedData.sort(), 5);
 
 			if (args.page <= list.length && args.page > 0) {
-				if (resolvedData.length === 0) {
-					args.send(`There are no ${options.dataType} to view.`);
+				if (Number.isInteger(args.page)) {
+					if (resolvedData.length === 0) {
+						args.send(`There are no ${options.dataType} to view.`);
+					} else {
+						const endText = options.footer ? "\n\n" + options.footer : "";
+						args.send(`${resolvedData.length} ${options.dataType} (page ${args.page} of ${list.length}): \n\n• ${list[args.page - 1].join("\n• ")}${endText}`);
+					}
 				} else {
-					const endText = options.footer ? "\n\n" + options.footer : "";
-					args.send(`${resolvedData.length} ${options.dataType} (page ${args.page} of ${list.length}): \n\n• ${list[args.page - 1].join("\n• ")}${endText}`);
+					args.send("Page numbers must be integers.");
 				}
 			} else {
 				args.send("That's an invalid page number!");


### PR DESCRIPTION
This pull request fixes the issue of a broken help if the page requested is not an integer (eg. `help 1.5`), instead offering a friendly error response.