### PR TITLE
Add the event message setter utility

### DIFF
--- a/src/commands/eventmessage/setjoinmessage.js
+++ b/src/commands/eventmessage/setjoinmessage.js
@@ -1,6 +1,7 @@
-const ems = require("./../utils/event-message-setter.js");
+const ems = require("./../../utils/event-message-setter.js");
 
 module.exports = ems("setjoinmessage", {
+	category: "eventmessage",
 	command: {
 		aliases: [
 			"joinmessage",

--- a/src/commands/eventmessage/setleavemessage.js
+++ b/src/commands/eventmessage/setleavemessage.js
@@ -1,6 +1,7 @@
-const ems = require("./../utils/event-message-setter.js");
+const ems = require("./../../utils/event-message-setter.js");
 
 module.exports = ems("setleavemessage", {
+	category: "eventmessage",
 	command: {
 		aliases: [
 			"leavemessage",

--- a/src/commands/setjoinmessage.js
+++ b/src/commands/setjoinmessage.js
@@ -18,4 +18,6 @@ module.exports = ems("setjoinmessage", {
 		description: "Sets the message announced after a user joins.",
 	},
 	longDescription: "Sets the message that is sent when a user joins the channel.",
+	msgType: "join_message",
+	storageKey: "join_message",
 });

--- a/src/commands/setjoinmessage.js
+++ b/src/commands/setjoinmessage.js
@@ -1,39 +1,21 @@
-module.exports = {
-	aliases: [
-		"joinmessage",
-		"setjoinmsg",
-		"joinmsg",
-		"setwelcomemessage",
-		"welcomemessage",
-		"setwelcomemsg",
-		"welcomemsg",
-		"sethellomessage",
-		"hellomessage",
-		"sethellomsg",
-		"hellomsg",
-	],
-	arguments: [{
-		description: "The new join message.",
-		key: "join-message",
-		type: "string",
-	}],
-	description: "Sets the message announced after a user joins.",
-	handler: args => {
-		const oldMsg = args.settings.get("join_message");
-		if (args.joinMessage) {
-			if (oldMsg === args.joinMessage) {
-				args.send(args.localize("update_join_message_no_change"));
-			} else {
-				args.settings.set("join_message", args.joinMessage);
-				args.send(args.localize("update_join_message"));
-			}
-		} else if (oldMsg === undefined) {
-			args.send(args.localize("clear_join_message_no_change"));
-		} else {
-			args.settings.clear("join_message");
-			args.send(args.localize("clear_join_message"));
-		}
+const ems = require("./../utils/event-message-setter.js");
+
+module.exports = ems("setjoinmessage", {
+	command: {
+		aliases: [
+			"joinmessage",
+			"setjoinmsg",
+			"joinmsg",
+			"setwelcomemessage",
+			"welcomemessage",
+			"setwelcomemsg",
+			"welcomemsg",
+			"sethellomessage",
+			"hellomessage",
+			"sethellomsg",
+			"hellomsg",
+		],
+		description: "Sets the message announced after a user joins.",
 	},
-	longDescription: "Sets the message that is sent when a user joins the channel. {USER} is replaced with the user's name.",
-	name: "setjoinmessage",
-};
+	longDescription: "Sets the message that is sent when a user joins the channel.",
+});

--- a/src/commands/setleavemessage.js
+++ b/src/commands/setleavemessage.js
@@ -1,43 +1,25 @@
-module.exports = {
-	aliases: [
-		"leavemessage",
-		"setleavemsg",
-		"leavemsg",
-		"setquitmessage",
-		"quitmessage",
-		"setquitmsg",
-		"quitmsg",
-		"setgoodbyemessage",
-		"goodbyemessage",
-		"setgoodbyemsg",
-		"goodbyemsg",
-		"setbyemessage",
-		"byemessage",
-		"setbyemsg",
-		"byemsg",
-	],
-	arguments: [{
-		description: "The new leave message.",
-		key: "leave-message",
-		type: "string",
-	}],
-	description: "Sets the message announced after a user leaves.",
-	handler: args => {
-		const oldMsg = args.settings.get("join_message");
-		if (args.leaveMessage) {
-			if (oldMsg === args.leaveMessage) {
-				args.send(args.localize("update_leave_message_no_change"));
-			} else {
-				args.settings.set("leave_message", args.leaveMessage);
-				args.send(args.localize("update_leave_message"));
-			}
-		} else if (oldMsg === undefined) {
-			args.send(args.localize("clear_leave_message_no_change"));
-		} else {
-			args.settings.clear("leave_message");
-			args.send(args.localize("clear_leave_message"));
-		}
+const ems = require("./../utils/event-message-setter.js");
+
+module.exports = ems("setleavemessage", {
+	command: {
+		aliases: [
+			"leavemessage",
+			"setleavemsg",
+			"leavemsg",
+			"setquitmessage",
+			"quitmessage",
+			"setquitmsg",
+			"quitmsg",
+			"setgoodbyemessage",
+			"goodbyemessage",
+			"setgoodbyemsg",
+			"goodbyemsg",
+			"setbyemessage",
+			"byemessage",
+			"setbyemsg",
+			"byemsg",
+		],
+		description: "Sets the message announced after a user leaves.",
 	},
-	longDescription: "Sets the message that is sent when a user leaves the channel. {USER} is replaced with the user's name.",
-	name: "setleavemessage",
-};
+	longDescription: "Sets the message that is sent when a user leaves the channel.",
+});

--- a/src/commands/setleavemessage.js
+++ b/src/commands/setleavemessage.js
@@ -22,4 +22,6 @@ module.exports = ems("setleavemessage", {
 		description: "Sets the message announced after a user leaves.",
 	},
 	longDescription: "Sets the message that is sent when a user leaves the channel.",
+	msgType: "leave_message",
+	storageKey: "leave_message",
 });

--- a/src/locales.json
+++ b/src/locales.json
@@ -32,16 +32,6 @@
 		"bytes_argument_invalid": "The value provided for the '{key}' argument must be a proper value and unit of digital storage.",
 		"bytes_conversion": "Converting that amount of bytes gives us {}.",
 		"bytes_conversion_failed": "I could not convert those bytes.",
-		"clear_join_message": "The join message will not be sent.",
-		"clear_join_message_no_change": [
-			"I haven't been sending the join message.",
-			"I'd stop sending the join message, if not for the fact that I haven't been doing that in the first place."
-		],
-		"clear_leave_message": "The leave message will not be sent.",
-		"clear_leave_message_no_change": [
-			"I haven't been sending the leave message.",
-			"I'd stop sending the leave message, if not for the fact that I haven't been doing that in the first place."
-		],
 		"color_amount_too_high": "I cannot provide you with {} colors because that would spam this chat.",
 		"color_amount_too_low": "I need to provide you with at least one name for this color.",
 		"color_argument_invalid": "The {2} for the '{key}' argument must be specified as a name, RGB, HSL, or hexadecimal code.",
@@ -97,6 +87,14 @@
 		],
 		"duration": "That duration is {} seconds.",
 		"duration_argument_invalid": "The {2} provided for the '{key}' argument could not be parsed.",
+		"event_message": "event message",
+		"event_message_clear": "The {} will not be sent.",
+		"event_message_clear_no_change": [
+			"I haven't been sending the {}.",
+			"I'd stop sending the {}, if not for the fact that I haven't been doing that in the first place."
+		],
+		"event_message_update": "The {} has been updated.",
+		"event_message_update_no_change": "That is already the {}.",
 		"faq_datatype": "FAQs",
 		"faq_nonexistent": "There is no FAQ with that identifier. For a list of FAQs that exist, type {}listfaq.",
 		"faq_unspecified": "You need to specify an identifier for the FAQ you want to show. To find this list, type {}listfaq.",
@@ -152,6 +150,7 @@
 			"Right now, the ISS is in space (obviously), at {}°, {}°."
 		],
 		"iss_location_type": "ISS location",
+		"join_message": "join message",
 		"lang_datatype": "languages",
 		"langs_footer": "You can change the language with {prefix}setlang <lang>, where <lang> is one of the codes seen above.",
 		"language": "English (American)",
@@ -163,6 +162,7 @@
 			"My language has been updated to {} here.",
 			"I'll now speak {} here."
 		],
+		"leave_message": "leave message",
 		"new_language_unspecified": "To change my language, you must specify the new language.",
 		"no_faqs": "There are no {type}. You can make one by using {prefix}setfaq.",
 		"no_pagination_items": "There are no {} to view.",
@@ -217,10 +217,6 @@
 			"Please specify the text to reverse.",
 			"What text would you like me to reverse?"
 		],
-		"update_join_message": "The join message has been updated.",
-		"update_join_message_no_change": "That is already the join message.",
-		"update_leave_message": "The leave message has been updated.",
-		"update_leave_message_no_change": "That is already the leave message.",
 		"urban_dictionary_no_result": [
 			"There was no result for that word on Urban Dictionary!",
 			"That word is not currently in Urban Dictionary."

--- a/src/utils/event-message-setter.js
+++ b/src/utils/event-message-setter.js
@@ -9,7 +9,6 @@ module.exports = (command, opts = {}) => {
 	const options = {
 		longDescription: "Sets the message sent when an event occurs.",
 		msgType: "event_message",
-		storageKey: "event_message",
 		...opts,
 	};
 
@@ -21,19 +20,21 @@ module.exports = (command, opts = {}) => {
 		}],
 		description: "Sets the event message.",
 		handler: args => {
+			const msgTypeLocal = args.localize(options.msgType) || args.localize("event_message");
+
 			const oldMsg = args.settings.get(options.storageKey);
 			if (args.eventMessage) {
 				if (oldMsg === args.eventMessage) {
-					args.send(args.localize(options.msgType + "_update_no_change"));
+					args.send(args.localize("event_message_update_no_change", msgTypeLocal));
 				} else {
 					args.settings.set(options.storageKey, args.eventMessage);
-					args.send(args.localize(options.msgType + "_update"));
+					args.send(args.localize("event_message_update", msgTypeLocal));
 				}
 			} else if (oldMsg === undefined) {
-				args.send(args.localize(options.msgType + "_clear_no_change"));
+				args.send(args.localize("event_message_clear_no_change", msgTypeLocal));
 			} else {
 				args.settings.clear(options.storageKey);
-				args.send(args.localize(options.msgType + "_clear"));
+				args.send(args.localize("event_message_clear", msgTypeLocal));
 			}
 		},
 		longDescription: options.longDescription + " {USER} is replaced with the user's name.",

--- a/src/utils/event-message-setter.js
+++ b/src/utils/event-message-setter.js
@@ -1,0 +1,39 @@
+/**
+ * Creates a setter command for event messages.
+ */
+module.exports = (command, opts = {}) => {
+	const options = {
+		longDescription: "Sets the message sent when an event occurs.",
+		msgType: "event_message",
+		storageKey: "event_message",
+		...opts,
+	};
+
+	return {
+		arguments: [{
+			description: "The new message.",
+			key: "event-message",
+			type: "string",
+		}],
+		description: "Sets the event message.",
+		handler: args => {
+			const oldMsg = args.settings.get(options.storageKey);
+			if (args.eventMessage) {
+				if (oldMsg === args.eventMessage) {
+					args.send(args.localize(options.msgType + "_update_no_change"));
+				} else {
+					args.settings.set(options.storageKey, args.eventMessage);
+					args.send(args.localize(options.msgType + "_update"));
+				}
+			} else if (oldMsg === undefined) {
+				args.send(args.localize(options.msgType + "_clear_no_change"));
+			} else {
+				args.settings.clear(options.storageKey);
+				args.send(args.localize(options.msgType + "_clear"));
+			}
+		},
+		longDescription: options.longDescription + " {USER} is replaced with the user's name.",
+		name: command,
+		...options.command,
+	};
+};

--- a/src/utils/event-message-setter.js
+++ b/src/utils/event-message-setter.js
@@ -2,6 +2,10 @@
  * Creates a setter command for event messages.
  */
 module.exports = (command, opts = {}) => {
+	if (!opts.storageKey) {
+		throw new Error(`Missing the storage key for the event message set by command ${command}`);
+	}
+
 	const options = {
 		longDescription: "Sets the message sent when an event occurs.",
 		msgType: "event_message",


### PR DESCRIPTION
This de-duplicates code shared by `setjoinmessage` and `setleavemessage` by creating the event message setter utility.