### PR TITLE
Add tests for localization completeness

### DIFF
--- a/src/locales.json
+++ b/src/locales.json
@@ -307,7 +307,7 @@
 		"github": "Meu codigo sorce esta disponivel em {}!",
 		"info": "Eu sou O u/{0}, pronto pra te ajudar!\nO meu prefixo é {1}, Faça {1}command para ver todos os comandos.\nEu fui feito por haykam821, e traduzido para Portugues por GammaRaul, mas por favor mande todas as perguntas via {1}feedback.",
 		"invalid_timezone": "Isso não é um fuso horario valido.",
-		"language": "Portugues",
+		"language": "Português (Brasileiro)",
 		"language_not_available": "Desculpa, mas, essa linguagem não esta disponivel no momento.",
 		"language_updated": "O indioma de Snooful foi mudado com sucesso.",
 		"new_language_unspecified": "Para mudar a linguagem de Snooful, voce precisa falar qual linguagem voce quer que ele fale.",

--- a/test.js
+++ b/test.js
@@ -69,8 +69,11 @@ function localizationFormatTests(locale = {}) {
 }
 
 describe("localizations", () => {
+	const englishKeys = Object.keys(locales["en-US"]);
 	Object.keys(locales).forEach(key => {
 		const locale = locales[key];
+		const keys = Object.keys(locale);
+
 		describe(`${key} locale`, () => {
 			it("has a correct locale code", () => {
 				assert.isTrue(validate(key));
@@ -80,12 +83,12 @@ describe("localizations", () => {
 				assert.notDeepEqual(locale, {});
 			});
 			it("has alphabetically-sorted keys", () => {
-				assert.isTrue(alphaSorted(Object.keys(locale)));
+				assert.isTrue(alphaSorted(keys));
 			});
 
 			if (key !== "en-US") {
 				it("has all keys in English localization", () => {
-					const keyPercent = Math.floor(Object.keys(locale).length / Object.keys(locales["en-US"]).length * 100);
+					const keyPercent = Math.floor(keys.length / englishKeys.length * 100);
 					assert.strictEqual(keyPercent, 100, `Only has ${keyPercent}% of keys`);
 				});
 			}

--- a/test.js
+++ b/test.js
@@ -42,30 +42,36 @@ function localizationFormatTests(locale = {}) {
 	});
 
 	// Now we can test these
-	it("arrays contain only strings", () => {
-		arrValues.every(arrValue => {
-			return arrValue.every(arrValueElem => {
-				return typeof arrValueElem === "string";
+	if (arrValues.length > 0) {
+		it("arrays contain only strings", () => {
+			arrValues.every(arrValue => {
+				return arrValue.every(arrValueElem => {
+					return typeof arrValueElem === "string";
+				});
 			});
 		});
-	});
-	describe("object values", () => {
-		it("keys are integers", () => {
-			Object.keys(objValues).every(intMaybe => {
-				return Number.isInteger(intMaybe);
+	}
+	if (objValues.length > 0) {
+		describe("object values", () => {
+			it("keys are integers", () => {
+				Object.keys(objValues).every(intMaybe => {
+					return Number.isInteger(intMaybe);
+				});
+			});
+			it("values are strings", () => {
+				Object.values(objValues).every(strMaybe => {
+					return typeof strMaybe === "string";
+				});
 			});
 		});
-		it("values are strings", () => {
-			Object.values(objValues).every(strMaybe => {
-				return typeof strMaybe === "string";
+	}
+	if (otrValues.length > 0) {
+		it("other values are strings", () => {
+			otrValues.every(otrValue => {
+				return typeof otrValue === "string";
 			});
 		});
-	});
-	it("other values are strings", () => {
-		otrValues.every(otrValue => {
-			return typeof otrValue === "string";
-		});
-	});
+	}
 }
 
 describe("localizations", () => {

--- a/test.js
+++ b/test.js
@@ -82,11 +82,18 @@ describe("localizations", () => {
 			it("has alphabetically-sorted keys", () => {
 				assert.isTrue(alphaSorted(Object.keys(locale)));
 			});
-			
+
+			if (key !== "en-US") {
+				it("has all keys in English localization", () => {
+					const keyPercent = Math.floor(Object.keys(locale).length / Object.keys(locales["en-US"]).length * 100);
+					assert.strictEqual(keyPercent, 100, `Only has ${keyPercent}% of keys`);
+				});
+			}
+
 			it("language name is in proper format", () => {
 				const langCode = getLanguageCode(key);
 				const countryCode = getCountryCode(key).toLowerCase();
-				
+
 				if (langCode !== countryCode) {
 					// Regional variant of language
 					assert.match(locale.language, /\w+ \(\w+\)/);


### PR DESCRIPTION
This pull request adds a per-localization test for having 100% of the localizations. It is not run for the base language, `en-US`, because it'd always be 100%.