### PR TITLE
Add tests for commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"main": "./src/index.js",
 	"scripts": {
 		"lint": "eslint \"./**/*.js\"",
-		"test": "mocha ./test.js",
+		"test": "mocha ./tests",
 		"start": "pm2 start"
 	},
 	"repository": {

--- a/src/commands/eventmessage/setjoinmessage.js
+++ b/src/commands/eventmessage/setjoinmessage.js
@@ -1,7 +1,6 @@
 const ems = require("./../../utils/event-message-setter.js");
 
 module.exports = ems("setjoinmessage", {
-	category: "eventmessage",
 	command: {
 		aliases: [
 			"joinmessage",
@@ -16,6 +15,7 @@ module.exports = ems("setjoinmessage", {
 			"sethellomsg",
 			"hellomsg",
 		],
+		category: "eventmessage",
 		description: "Sets the message announced after a user joins.",
 	},
 	longDescription: "Sets the message that is sent when a user joins the channel.",

--- a/src/commands/eventmessage/setleavemessage.js
+++ b/src/commands/eventmessage/setleavemessage.js
@@ -1,7 +1,6 @@
 const ems = require("./../../utils/event-message-setter.js");
 
 module.exports = ems("setleavemessage", {
-	category: "eventmessage",
 	command: {
 		aliases: [
 			"leavemessage",
@@ -20,6 +19,7 @@ module.exports = ems("setleavemessage", {
 			"setbyemsg",
 			"byemsg",
 		],
+		category: "eventmessage",
 		description: "Sets the message announced after a user leaves.",
 	},
 	longDescription: "Sets the message that is sent when a user leaves the channel.",

--- a/src/commands/fun/birthday.js
+++ b/src/commands/fun/birthday.js
@@ -13,6 +13,7 @@ module.exports = {
 		key: "full-song",
 		type: "boolean",
 	}],
+	category: "fun",
 	description: "Sings a birthday song to a user!",
 	handler: args => {
 		if (args.user) {

--- a/src/commands/fun/echo.js
+++ b/src/commands/fun/echo.js
@@ -7,6 +7,7 @@ module.exports = {
 		key: "text",
 		type: "string",
 	}],
+	category: "fun",
 	description: "Repeats a message.",
 	handler: args => {
 		args.send("Sorry, but this command is temporarily disabled until our command restriction system is implemented. Sorry!");

--- a/src/commands/fun/feed.js
+++ b/src/commands/fun/feed.js
@@ -31,6 +31,7 @@ module.exports = {
 		key: "user",
 		type: "string",
 	}],
+	category: "fun",
 	description: "Feeds you or a specified user food.",
 	handler: args => {
 		if (args.user === undefined || args.user === args.author) {

--- a/src/commands/fun/lmgtfy.js
+++ b/src/commands/fun/lmgtfy.js
@@ -5,6 +5,7 @@ module.exports = {
 		key: "query",
 		type: "string",
 	}],
+	category: "fun",
 	description: "Gets a link to the LMGTFY service.",
 	handler: args => args.send(url`http://lmgtfy.com/?q=${args.query}`),
 	name: "lmgtfy",

--- a/src/commands/fun/mock.js
+++ b/src/commands/fun/mock.js
@@ -12,6 +12,7 @@ module.exports = {
 		required: true,
 		type: "string",
 	}],
+	category: "fun",
 	description: "Alternates a message's case.",
 	handler: args => {
 		const transformed = altCase(args.text);

--- a/src/commands/fun/urban.js
+++ b/src/commands/fun/urban.js
@@ -10,6 +10,7 @@ module.exports = {
 		key: "term",
 		type: "string",
 	}],
+	category: "fun",
 	describe: "Gets a term from Urban Dictionary.",
 	handler: args => {
 		if (args.term) {

--- a/src/commands/permissions/createrole.js
+++ b/src/commands/permissions/createrole.js
@@ -8,6 +8,7 @@ module.exports = {
 		key: "role",
 		type: "string",
 	}],
+	category: "permissions",
 	handler: args => {
 		const roleName = roleNameify(args.role);
 		const roles = args.settings.get("roles");

--- a/src/commands/permissions/deleterole.js
+++ b/src/commands/permissions/deleterole.js
@@ -7,6 +7,7 @@ module.exports = {
 		key: "role",
 		type: "string",
 	}],
+	category: "permissions",
 	handler: args => {
 		const roleName = roleNameify(args.role);
 		const roles = args.settings.get("roles");

--- a/src/commands/permissions/giveperm.js
+++ b/src/commands/permissions/giveperm.js
@@ -14,6 +14,7 @@ module.exports = {
 		key: "permission",
 		type: "string",
 	}],
+	category: "permissions",
 	handler: args => {
 		if (!validate(args.permission)) {
 			return args.send(args.localize("invalid_permission"));

--- a/src/commands/permissions/giverole.js
+++ b/src/commands/permissions/giverole.js
@@ -7,6 +7,7 @@ module.exports = {
 		key: "role",
 		type: "string",
 	}],
+	category: "permissions",
 	handler: args => {
 		const roleName = roleNameify(args.role);
 		const roles = args.settings.get("roles");

--- a/src/commands/permissions/roles.js
+++ b/src/commands/permissions/roles.js
@@ -3,6 +3,7 @@ module.exports = paginate("roles", args => {
 	return Object.keys(args.settings.get("roles"));
 }, {
 	command: {
+		category: "permissions",
 		description: "Lists the roles.",
 	},
 	dataType: "roles_datatype",

--- a/src/commands/permissions/takeperm.js
+++ b/src/commands/permissions/takeperm.js
@@ -14,6 +14,7 @@ module.exports = {
 		key: "permission",
 		type: "string",
 	}],
+	category: "permissions",
 	handler: args => {
 		if (!validate(args.permission)) {
 			return args.send(args.localize("invalid_permission"));

--- a/src/commands/permissions/takerole.js
+++ b/src/commands/permissions/takerole.js
@@ -10,6 +10,7 @@ module.exports = {
 		key: "role",
 		type: "string",
 	}],
+	category: "permissions",
 	handler: args => {
 		const roleName = roleNameify(args.role);
 		const roles = args.settings.get("roles");

--- a/src/commands/permissions/updatemods.js
+++ b/src/commands/permissions/updatemods.js
@@ -2,6 +2,7 @@ module.exports = {
 	aliases: [
 		"updatemoderators",
 	],
+	category: "permissions",
 	handler: args => {
 		if (!args.chData.subreddit) {
 			return args.send(args.localize("mod_update_not_subreddit"));

--- a/src/commands/permissions/userperms.js
+++ b/src/commands/permissions/userperms.js
@@ -1,6 +1,7 @@
 const paginate = require("./../../utils/paginate.js");
 module.exports = paginate("userperms", args => args.perms, {
 	command: {
+		category: "permissions",
 		description: "Lists the permissions a user has.",
 	},
 	dataType: "permissions_datatype",

--- a/src/commands/util/bytes.js
+++ b/src/commands/util/bytes.js
@@ -17,6 +17,7 @@ module.exports = {
 		key: "unit",
 		type: "string",
 	}],
+	category: "util",
 	description: "Converts bytes to a unit.",
 	handler: args => {
 		const convert = bytes.format(args.value, {

--- a/src/commands/util/duration.js
+++ b/src/commands/util/duration.js
@@ -8,6 +8,7 @@ module.exports = {
 		required: true,
 		type: "duration",
 	}],
+	category: "util",
 	description: "Gets the length of a duration in seconds.",
 	handler: args => {
 		args.send(args.localize("duration", args.duration / 1000));

--- a/src/commands/util/reverse.js
+++ b/src/commands/util/reverse.js
@@ -1,4 +1,4 @@
-const rev = require("./../utils/reverse.js");
+const rev = require("./../../utils/reverse.js");
 
 module.exports = {
 	arguments: [{

--- a/src/commands/util/reverse.js
+++ b/src/commands/util/reverse.js
@@ -6,6 +6,7 @@ module.exports = {
 		key: "text",
 		type: "string",
 	}],
+	category: "util",
 	description: "Reverses text.",
 	handler: args => {
 		if (args.text) {

--- a/src/commands/util/time.js
+++ b/src/commands/util/time.js
@@ -7,6 +7,7 @@ module.exports = {
 		key: "zone",
 		type: "string",
 	}],
+	category: "util",
 	description: "Gets the current time.",
 	handler: args => {
 		const zone = moment.tz.zone(args.zone);

--- a/src/commands/util/whereami.js
+++ b/src/commands/util/whereami.js
@@ -1,4 +1,5 @@
 module.exports = {
+	category: "util",
 	description: "Tells you where you are.",
 	handler: args => args.send(args.localize("whereami", args.channel.name)),
 	name: "whereami",

--- a/src/commands/util/whoami.js
+++ b/src/commands/util/whoami.js
@@ -1,4 +1,5 @@
 module.exports = {
+	category: "util",
 	description: "Tells you who you are.",
 	handler: args => args.send(args.localize("whoami", args.author)),
 	name: "whoami",

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -1,0 +1,18 @@
+/* eslint-env mocha */
+const assert = require("chai").assert;
+
+const orangered = require("@snooful/orangered-parser");
+orangered.registerDirectory("./src/commands");
+
+// Non-aliases, to prevent clogging
+const registry = orangered.getCommandRegistry().filter(cmd => {
+	return cmd.name === cmd.originalName;
+});
+
+describe("commands", () => {
+	it("have categories", () => {
+		registry.forEach(cmd => {
+			assert.isString(cmd.category, `${cmd.name} does not have a category`);
+		});
+	});
+});

--- a/tests/localization.js
+++ b/tests/localization.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 const assert = require("chai").assert;
 
-const locales = require("./src/locales.json");
+const locales = require("./../src/locales.json");
 const { validate, getLanguageCode, getCountryCode } = require("locale-code");
 
 const sorted = require("is-sorted");


### PR DESCRIPTION
This pull request adds tests for commands in addition to the existing ones for localizations. To keep tests organized, there is now a directory where files store each type of test (command and localization tests).