### PR TITLE
Parse config with cosmiconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"chance": "^1.0.17",
 		"clear-require": "^2.0.0",
 		"color-namer": "^1.3.0",
+		"cosmiconfig": "^5.1.0",
 		"didyoumean2": "^1.3.0",
 		"got": "^9.3.1",
 		"lodash.chunk": "^4.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,25 @@
-// Used to expose version and include config from `snooful` object
-const { version, snooful } = require("./../package.json");
+const { version } = require("./../package.json");
 
-const config = {
-	credentials: {},
-	prefix: "!",
-	settingsManager: "",
-	...snooful,
-	...require("./../config.json"),
-};
+const cosmic = require("cosmiconfig");
+const explorer = cosmic("snooful", {
+	searchPlaces: [
+		"package.json",
+		"config.json",
+		".snoofulrc",
+		".snoofulrc.json",
+		".snoofulrc.yaml",
+		".snoofulrc.yml",
+		".snoofulrc.js",
+		"snooful.config.js",
+	],
+	transform: result => ({
+		credentials: {},
+		prefix: "!",
+		settingsManager: "",
+		...result,
+	}),
+});
+const config = explorer.searchSync();
 
 const Snoowrap = require("snoowrap");
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,14 @@ try {
 const SettingsManager = setMan.SettingsManager || setMan;
 const extension = setMan.extension || "";
 
+const init = SettingsManager.prototype.init;
+SettingsManager.prototype.init = () => {
+	return false;
+};
+
 log.settings("passing off settings handling to the '%s' module", config.settingsManager);
 const settings = new SettingsManager(path.resolve("./settings" + extension));
+init.call(settings);
 
 const locales = require("./locales.json");
 const format = require("string-format");

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ const explorer = cosmic("snooful", {
 	transform: result => ({
 		credentials: {},
 		prefix: "!",
-		settingsManager: "",
-		...result,
+		settingsManager: "@snooful/sqlite-settings",
+		...result.config,
 	}),
 });
 const config = explorer.searchSync();
@@ -32,7 +32,18 @@ const eventMessageFactory = require("./utils/event-message-handler.js");
 const path = require("path");
 
 // Set up in a way where legacy settings managers work too
-const setMan = require(config.settingsManager);
+let setMan;
+try {
+	setMan = require(config.settingsManager);
+} catch (error) {
+	switch (error.code) {
+		case "MODULE_NOT_FOUND":
+			log.settings("could not find settings manager (you must run `npm install %s`)", config.settingsManager);
+			break;
+		default:
+			log.settings("error while loading settings manager");
+	}
+}
 const SettingsManager = setMan.SettingsManager || setMan;
 const extension = setMan.extension || "";
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,5 @@
 const { version } = require("./../package.json");
-
-const cosmic = require("cosmiconfig");
-const explorer = cosmic("snooful", {
-	searchPlaces: [
-		"package.json",
-		"config.json",
-		".snoofulrc",
-		".snoofulrc.json",
-		".snoofulrc.yaml",
-		".snoofulrc.yml",
-		".snoofulrc.js",
-		"snooful.config.js",
-	],
-	transform: result => ({
-		credentials: {},
-		prefix: "!",
-		settingsManager: "@snooful/sqlite-settings",
-		...result.config,
-	}),
-});
-const config = explorer.searchSync();
+const config = require("./utils/get-config.js")();
 
 const Snoowrap = require("snoowrap");
 

--- a/src/utils/get-config.js
+++ b/src/utils/get-config.js
@@ -1,0 +1,28 @@
+const cosmic = require("cosmiconfig");
+
+/**
+ * Gets the user-defined configuration for Snooful with defaults.
+ * @returns {object} The configuration object.
+ */
+function getConfig() {
+	const explorer = cosmic("snooful", {
+		searchPlaces: [
+			"package.json",
+			"config.json",
+			".snoofulrc",
+			".snoofulrc.json",
+			".snoofulrc.yaml",
+			".snoofulrc.yml",
+			".snoofulrc.js",
+			"snooful.config.js",
+		],
+		transform: result => ({
+			credentials: {},
+			prefix: "!",
+			settingsManager: "@snooful/sqlite-settings",
+			...result.config,
+		}),
+	});
+	return explorer.searchSync();
+}
+module.exports = getConfig;


### PR DESCRIPTION
**UNTESTED**

This pull request allows configs to be loaded from these locations in addition to `config.json` and the `snooful` property of `package.json`:

* `.snoofulrc`
* `.snoofulrc.json`
* `.snoofulrc.yaml`
* `.snoofulrc.yml`
* `.snoofulrc.js`
* `snooful.config.js`