### PR TITLE
Allow customizing a global prefix in addition to a normal prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Switching the settings manager does not transfer the existing data. However, you
 
 ### Prefix
 
-You can also configure the prefix from the default `!` by setting `prefix`. The prefix is the thing that differentiates a command from a message. Basically, with a prefix of `?`, you must type `?ping` to run the `ping` command.
+You can also configure the prefix from the default `!` by setting `prefix.start`. The prefix is the thing that differentiates a command from a message. Basically, with a prefix of `?`, you must type `?ping` to run the `ping` command.
+
+While disabled by default, it is also possible to configure a global prefix at `prefix.global`. This prefix works anywhere in a message, and everything after the prefix will be considered an argument to the command.
 
 *Please change the prefix if you are hosting your own version of Snooful.*
 
@@ -58,7 +60,10 @@ Here is an example configuration:
 
 ```json
 {
-  "prefix": "?",
+  "prefix": {
+	"start": "?",
+	"global": "--"
+  },
   "credentials": {
     "clientId": "a897d89f89e",
     "clientSecret": "0202390301209919219810929012",

--- a/src/index.js
+++ b/src/index.js
@@ -37,25 +37,6 @@ log.settings("passing off settings handling to the '%s' module", config.settings
 const settings = new SettingsManager(path.resolve("./settings" + extension));
 init.call(settings);
 
-const locales = require("./locales.json");
-const format = require("string-format");
-const upsidedown = require("upsidedown");
-
-const chance = new require("chance").Chance();
-/**
- * Selects a string.
- * @param {(Object|any[]|*)} msg If an object, selects an key based on the weight value. If an array, picks a random element. Otherwise, converts to a string.
- */
-function chanceFormats(msg) {
-	if (Array.isArray(msg)) {
-		return chance.pickone(msg);
-	} else if (msg instanceof Object) {
-		return chance.weighted(Object.keys(msg), Object.values(msg));
-	} else {
-		return msg.toString();
-	}
-}
-
 /**
  * The prefix required by commands to be considered by the bot.
  */
@@ -92,26 +73,8 @@ process.on("unhandledException", safeFail);
  */
 let client = {};
 
-/**
- * Formats a string.
- * @param {string} lang A language code. If the key is not localized in this language or this value is not provided, uses en-US.
- * @param {string} key The key to localize.
- * @param {...any} formats The values to provide for placeholders.
- * @return {?string} A string if a localization could be provided, or null.
- */
-function localize(lang = "en-US", key = "", ...formats) {
-	const thisLocal = lang ? (locales[lang] || locales["en-US"]) : locales["en-US"];
-	const msg = thisLocal[key] || locales["en-US"][key];
-
-	if (msg) {
-		const msgChosen = chanceFormats(msg);
-
-		const formatted = format(msgChosen, ...formats);
-		return lang === "uǝ" ? upsidedown(formatted) : formatted;
-	} else {
-		return null;
-	}
-}
+const locales = require("./locales.json");
+const localize = require("./utils/localize.js");
 
 const pp = require("@snooful/periwinkle-permissions");
 const userPerms = require("./utils/user-perms.js");

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -14,6 +14,10 @@ try {
 	 */
 module.exports.commands = debug("snooful:commands");
 /**
+	 * Debug for configuration loading and parsing.
+	 */
+module.exports.configuration = debug("snooful:configuration");
+/**
 	 * Debug for join and leave messages.
 	 */
 module.exports.gateway = debug("snooful:gateway");

--- a/src/utils/get-config.js
+++ b/src/utils/get-config.js
@@ -1,4 +1,5 @@
 const cosmic = require("cosmiconfig");
+const { configuration: log } = require("./debug.js");
 
 /**
  * Transforms a config.
@@ -15,6 +16,9 @@ function transformConfig(result) {
 	};
 
 	if (typeof newConfig.prefix === "string") {
+		log("changed prefix configuration to use object instead of string");
+
+		newConfig.prefix = {};
 		newConfig.prefix.start = result.config.prefix;
 		newConfig.prefix.global = null;
 	}
@@ -41,6 +45,12 @@ function getConfig() {
 		],
 		transform: transformConfig,
 	});
-	return explorer.searchSync().config;
+
+	const result = explorer.searchSync();
+
+	log("loaded configuration from '%s'", result.filepath);
+	log("loaded configuration: %O", result.config);
+
+	return result.config;
 }
 module.exports = getConfig;

--- a/src/utils/get-config.js
+++ b/src/utils/get-config.js
@@ -1,6 +1,29 @@
 const cosmic = require("cosmiconfig");
 
 /**
+ * Transforms a config.
+ */
+function transformConfig(result) {
+	const newConfig = {
+		credentials: {},
+		prefix: {
+			global: null,
+			start: "!",
+		},
+		settingsManager: "@snooful/sqlite-settings",
+		...result.config,
+	};
+
+	if (typeof newConfig.prefix === "string") {
+		newConfig.prefix.start = result.config.prefix;
+		newConfig.prefix.global = null;
+	}
+
+	result.config = newConfig;
+	return result;
+}
+
+/**
  * Gets the user-defined configuration for Snooful with defaults.
  * @returns {object} The configuration object.
  */
@@ -16,13 +39,8 @@ function getConfig() {
 			".snoofulrc.js",
 			"snooful.config.js",
 		],
-		transform: result => ({
-			credentials: {},
-			prefix: "!",
-			settingsManager: "@snooful/sqlite-settings",
-			...result.config,
-		}),
+		transform: transformConfig,
 	});
-	return explorer.searchSync();
+	return explorer.searchSync().config;
 }
 module.exports = getConfig;

--- a/src/utils/localize.js
+++ b/src/utils/localize.js
@@ -1,4 +1,4 @@
-const locales = require("./locales.json");
+const locales = require("../locales.json");
 const format = require("string-format");
 const upsidedown = require("upsidedown");
 

--- a/src/utils/localize.js
+++ b/src/utils/localize.js
@@ -1,0 +1,40 @@
+const locales = require("./locales.json");
+const format = require("string-format");
+const upsidedown = require("upsidedown");
+
+const chance = new require("chance").Chance();
+/**
+ * Selects a string.
+ * @param {(Object|any[]|*)} msg If an object, selects an key based on the weight value. If an array, picks a random element. Otherwise, converts to a string.
+ */
+function chanceFormats(msg) {
+	if (Array.isArray(msg)) {
+		return chance.pickone(msg);
+	} else if (msg instanceof Object) {
+		return chance.weighted(Object.keys(msg), Object.values(msg));
+	} else {
+		return msg.toString();
+	}
+}
+
+/**
+ * Formats a string.
+ * @param {string} lang A language code. If the key is not localized in this language or this value is not provided, uses en-US.
+ * @param {string} key The key to localize.
+ * @param {...any} formats The values to provide for placeholders.
+ * @return {?string} A string if a localization could be provided, or null.
+ */
+function localize(lang = "en-US", key = "", ...formats) {
+	const thisLocal = lang ? (locales[lang] || locales["en-US"]) : locales["en-US"];
+	const msg = thisLocal[key] || locales["en-US"][key];
+
+	if (msg) {
+		const msgChosen = chanceFormats(msg);
+
+		const formatted = format(msgChosen, ...formats);
+		return lang === "uǝ" ? upsidedown(formatted) : formatted;
+	} else {
+		return null;
+	}
+}
+module.exports = localize;


### PR DESCRIPTION
This pull request allows a secondary prefix that works anywhere in a message, with the rest of the message becoming arguments for the commands.

For example, with the global prefix `—`, the following messages will work as commands:

* Start of a message: `—ping args`
* Middle of a message: `Hello world —ping args`
* Middle of a message, without separation: `Here—ping args`

The global prefix is disabled by default.